### PR TITLE
Added support for external application cache

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -129,14 +129,6 @@
   revision = "6243d8e04c3f819e79757e8bc3faa15c3cb27003"
 
 [[projects]]
-  digest = "1:808cdddf087fb64baeae67b8dfaee2069034d9704923a3cb8bd96a995421a625"
-  name = "github.com/patrickmn/go-cache"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
-  version = "v2.1.0"
-
-[[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -245,7 +237,6 @@
     "github.com/cloudfoundry/sonde-go/events",
     "github.com/gobwas/glob",
     "github.com/kelseyhightower/envconfig",
-    "github.com/patrickmn/go-cache",
     "github.com/rcrowley/go-metrics",
     "github.com/stretchr/testify/assert",
     "github.com/wavefronthq/go-metrics-wavefront/reporting",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,14 +34,6 @@
   revision = "f136f9222381e2fea5099f62e4b751dcb660ff82"
 
 [[projects]]
-  branch = "master"
-  digest = "1:748e0542f42470c57952bca598d750ea1b77fbc479425902c3ad9f11f2911685"
-  name = "github.com/cloudfoundry-incubator/uaago"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "8136b7bbe76e26394600a790a95c15eac955f4fc"
-
-[[projects]]
   digest = "1:9148c060d019cb181efbabd6e5858e7727796d62d16f002f23addcf2cc374818"
   name = "github.com/cloudfoundry/noaa"
   packages = [
@@ -106,6 +98,14 @@
   pruneopts = "UT"
   revision = "c823c79ea1570fb5ff454033735a8e68575d1d0f"
   version = "v1.3.0"
+
+[[projects]]
+  digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:7b5c6e2eeaa9ae5907c391a91c132abfd5c9e8a784a341b5625e750c67e6825d"
@@ -241,10 +241,10 @@
   analyzer-version = 1
   input-imports = [
     "github.com/cloudfoundry-community/go-cfclient",
-    "github.com/cloudfoundry-incubator/uaago",
     "github.com/cloudfoundry/noaa/consumer",
     "github.com/cloudfoundry/sonde-go/events",
     "github.com/gobwas/glob",
+    "github.com/google/uuid",
     "github.com/kelseyhightower/envconfig",
     "github.com/rcrowley/go-metrics",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
   revision = "f136f9222381e2fea5099f62e4b751dcb660ff82"
 
 [[projects]]
+  branch = "master"
+  digest = "1:748e0542f42470c57952bca598d750ea1b77fbc479425902c3ad9f11f2911685"
+  name = "github.com/cloudfoundry-incubator/uaago"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8136b7bbe76e26394600a790a95c15eac955f4fc"
+
+[[projects]]
   digest = "1:9148c060d019cb181efbabd6e5858e7727796d62d16f002f23addcf2cc374818"
   name = "github.com/cloudfoundry/noaa"
   packages = [
@@ -233,6 +241,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/cloudfoundry-community/go-cfclient",
+    "github.com/cloudfoundry-incubator/uaago",
     "github.com/cloudfoundry/noaa/consumer",
     "github.com/cloudfoundry/sonde-go/events",
     "github.com/gobwas/glob",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,10 +26,6 @@
   name = "github.com/gobwas/glob"
   version = "0.2.3"
 
-[[constraint]]
-  name = "github.com/patrickmn/go-cache"
-  version = "2.1.0"
-
 [prune]
   go-tests = true
   unused-packages = true

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,10 +3,6 @@
   name = "github.com/cloudfoundry-community/go-cfclient"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/cloudfoundry-incubator/uaago"
-
-[[constraint]]
   name = "github.com/cloudfoundry/noaa"
   version = "2.1.0"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,6 +3,10 @@
   name = "github.com/cloudfoundry-community/go-cfclient"
 
 [[constraint]]
+  branch = "master"
+  name = "github.com/cloudfoundry-incubator/uaago"
+
+[[constraint]]
   name = "github.com/cloudfoundry/noaa"
   version = "2.1.0"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,6 +26,10 @@
   name = "github.com/gobwas/glob"
   version = "0.2.3"
 
+[[constraint]]
+  name = "github.com/google/uuid"
+  version = "1.1.1"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	noaaConsumer := consumer.New(trafficControllerURL, &tls.Config{
 		InsecureSkipVerify: conf.Nozzle.SkipSSL,
 	}, nil)
+	noaaConsumer.SetDebugPrinter(loggerDebugPrinter{})
 	events, errs := noaaConsumer.Firehose(conf.Nozzle.FirehoseSubscriptionID, token)
 
 	wavefront := nozzle.CreateEventHandler(conf.Wavefront)
@@ -56,4 +57,11 @@ func main() {
 	if err != nil {
 		logger.Fatal("[ERROR] Error forwarding", err)
 	}
+}
+
+type loggerDebugPrinter struct {
+}
+
+func (loggerDebugPrinter) Print(title, body string) {
+	logger.Printf("[%s] %s", title, body)
 }

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/cloudfoundry-incubator/uaago"
 	"github.com/cloudfoundry/noaa/consumer"
 	"github.com/wavefronthq/cloud-foundry-nozzle-go/nozzle"
 )
@@ -26,7 +25,7 @@ func main() {
 	}
 
 	var trafficControllerURL string
-	logger.Printf("Fetching auth token via UAA: %v\n", conf.Nozzle.UAAURL)
+	logger.Printf("Fetching auth token via UAA: %v\n", conf.Nozzle.APIURL)
 
 	// Set up connection to PAS API using the token we got
 	api, err := nozzle.NewAPIClient(conf.Nozzle)
@@ -57,18 +56,4 @@ func main() {
 	if err != nil {
 		logger.Fatal("[ERROR] Error forwarding", err)
 	}
-}
-
-func fetchAuthToken(url, username, password string, skipSSL bool) (string, error) {
-	uaaClient, err := uaago.NewClient(url)
-	if err != nil {
-		return "", err
-	}
-
-	var authToken string
-	authToken, err = uaaClient.GetAuthToken(username, password, skipSSL)
-	if err != nil {
-		return "", err
-	}
-	return authToken, nil
 }

--- a/nozzle/api_client.go
+++ b/nozzle/api_client.go
@@ -50,6 +50,7 @@ func NewAPIClient(conf *NozzleConfig) (*APIClient, error) {
 	}
 
 	var cache Cache
+	logger.Printf("Preloader URL is set to: %s, size is %d", conf.AppCachePreloader, conf.AppCacheSize)
 	if conf.AppCachePreloader != "" {
 		cache = NewPreloadedCache(conf.AppCachePreloader, conf.AppCacheSize)
 	} else {

--- a/nozzle/api_client.go
+++ b/nozzle/api_client.go
@@ -17,13 +17,6 @@ type APIClient struct {
 	expiration   time.Duration
 }
 
-// AppInfo holds Cloud Foundry applications information
-type AppInfo struct {
-	Name  string
-	Space string
-	Org   string
-}
-
 func newAppInfo(app cfclient.App) *AppInfo {
 	space, err := app.Space()
 	if err != nil {
@@ -56,11 +49,18 @@ func NewAPIClient(conf *NozzleConfig) (*APIClient, error) {
 		return nil, err
 	}
 
+	var cache Cache
+	if conf.AppCachePreloader != "" {
+		cache = NewPreloadedCache(conf.AppCachePreloader)
+	} else {
+		cache = NewRandomEvictionCache(conf.AppCacheSize)
+	}
+
 	return &APIClient{
 		clientConfig: config,
 		client:       client,
 		expiration:   conf.AppCacheExpiration,
-		appCache:     NewRandomEvictionCache(conf.AppCacheSize),
+		appCache:     cache,
 	}, nil
 }
 

--- a/nozzle/api_client.go
+++ b/nozzle/api_client.go
@@ -51,7 +51,7 @@ func NewAPIClient(conf *NozzleConfig) (*APIClient, error) {
 
 	var cache Cache
 	if conf.AppCachePreloader != "" {
-		cache = NewPreloadedCache(conf.AppCachePreloader)
+		cache = NewPreloadedCache(conf.AppCachePreloader, conf.AppCacheSize)
 	} else {
 		cache = NewRandomEvictionCache(conf.AppCacheSize)
 	}

--- a/nozzle/api_client.go
+++ b/nozzle/api_client.go
@@ -39,8 +39,8 @@ func newAppInfo(app cfclient.App) *AppInfo {
 func NewAPIClient(conf *NozzleConfig) (*APIClient, error) {
 	config := &cfclient.Config{
 		ApiAddress:        conf.APIURL,
-		Username:          conf.Username,
-		Password:          conf.Password,
+		ClientID:          conf.Username,
+		ClientSecret:      conf.Password,
 		SkipSslValidation: conf.SkipSSL,
 	}
 
@@ -96,7 +96,7 @@ func (api *APIClient) GetApp(guid string) (*AppInfo, error) {
 	//size := metrics.GetOrRegisterGauge("cache.size", nil)
 	errors := metrics.GetOrRegisterCounter("cache.errors", nil)
 	miss := metrics.GetOrRegisterCounter("cache.miss", nil)
-	// size.Update(int64(api.appCache.ItemCount())) TODO! Try to make redis support this.
+	// size.Update(int64(api.appCache.ItemCount()))
 
 	appInfo, found := api.appCache.Get(guid)
 	if found {

--- a/nozzle/cache.go
+++ b/nozzle/cache.go
@@ -19,3 +19,9 @@ type Preloader interface {
 	// GetAllApps loads the entire list of applications
 	GetAllApps() ([]AppInfo, error)
 }
+
+// CacheSource is called when a key isn't found in the cache. It's supposed to connect to some backend data source.
+type CacheSource interface {
+	// GetUncached tries to look up an object in some backend source. It returns an error if not successful.
+	GetUncached(key string) (*AppInfo, error)
+}

--- a/nozzle/cache.go
+++ b/nozzle/cache.go
@@ -1,0 +1,10 @@
+package nozzle
+
+import "time"
+
+// Cache is an abstract representation of a cache capable of holding e.g. AppInfo records. It must
+// support expiration of cache items.
+type Cache interface {
+	Get(key string) (interface{}, bool)
+	Set(key string, value interface{}, ttl time.Duration)
+}

--- a/nozzle/cache.go
+++ b/nozzle/cache.go
@@ -12,3 +12,10 @@ type Cache interface {
 	// from the cache if it's already at capacity.
 	Set(key string, value interface{}, ttl time.Duration)
 }
+
+// Preloader represents a class that's capable of loading the entire list of applications
+// from CF.
+type Preloader interface {
+	// GetAllApps loads the entire list of applications
+	GetAllApps() ([]AppInfo, error)
+}

--- a/nozzle/cache.go
+++ b/nozzle/cache.go
@@ -5,6 +5,10 @@ import "time"
 // Cache is an abstract representation of a cache capable of holding e.g. AppInfo records. It must
 // support expiration of cache items.
 type Cache interface {
+	// Get returns the value for the key if it exists. If it doesn't exist, (nil, false) is returned.
 	Get(key string) (interface{}, bool)
+
+	// Set puts a key-value pair into the cache. Depending on the implementation, items may be evicted
+	// from the cache if it's already at capacity.
 	Set(key string, value interface{}, ttl time.Duration)
 }

--- a/nozzle/config.go
+++ b/nozzle/config.go
@@ -19,14 +19,14 @@ type Config struct {
 // NozzleConfig holds specific PCF env variables
 type NozzleConfig struct {
 	APIURL                 string `required:"true" envconfig:"api_url"`
-	UAAURL                 string `required:"true" envconfig:"uaa_url"`
-	Username               string `required:"true"`
-	Password               string `required:"true"`
+	ClientID               string `required:"true" envconfig:"client_id"`
+	ClientSecret           string `required:"true" envconfig:"client_secret"`
 	FirehoseSubscriptionID string `required:"true" envconfig:"firehose_subscription_id"`
 	SkipSSL                bool   `default:"false" envconfig:"skip_ssl"`
 
 	AppCacheExpiration time.Duration `split_words:"true" default:"6h"`
 	AppCacheSize       int           `split_words:"true" default:"50000"`
+	PreloadAppCache    bool          `split_words:"true" default:"true"`
 
 	AppCachePreloader string `split_words:"true" default:""`
 
@@ -104,6 +104,16 @@ func ParseConfig() (*Config, error) {
 
 	config := &Config{Nozzle: nozzleConfig, Wavefront: wavefrontConfig}
 	return config, nil
+}
+
+// HasEventType returns true if a named event type is enabled.
+func (n *NozzleConfig) HasEventType(e events.Envelope_EventType) bool {
+	for _, s := range n.SelectedEvents {
+		if s == e {
+			return true
+		}
+	}
+	return false
 }
 
 // parseIndexedVars append the value of `varName_1, varName_2, varName_N` to `varName`.

--- a/nozzle/config.go
+++ b/nozzle/config.go
@@ -27,6 +27,8 @@ type NozzleConfig struct {
 	AppCacheExpiration time.Duration `split_words:"true" default:"6h"`
 	AppCacheSize       int           `split_words:"true" default:"50000"`
 
+	AppCachePreloader string `split_words:"true" default:""`
+
 	SelectedEvents []events.Envelope_EventType `ignored:"true"`
 }
 

--- a/nozzle/config.go
+++ b/nozzle/config.go
@@ -19,6 +19,7 @@ type Config struct {
 // NozzleConfig holds specific PCF env variables
 type NozzleConfig struct {
 	APIURL                 string `required:"true" envconfig:"api_url"`
+	UAAURL                 string `required:"true" envconfig:"uaa_url"`
 	Username               string `required:"true"`
 	Password               string `required:"true"`
 	FirehoseSubscriptionID string `required:"true" envconfig:"firehose_subscription_id"`

--- a/nozzle/config_test.go
+++ b/nozzle/config_test.go
@@ -11,9 +11,10 @@ import (
 
 func setUpFooEnv() {
 	os.Setenv("NOZZLE_API_URL", "foo")
-	os.Setenv("NOZZLE_USERNAME", "foo")
-	os.Setenv("NOZZLE_PASSWORD", "foo")
+	os.Setenv("NOZZLE_CLIENT_ID", "foo")
+	os.Setenv("NOZZLE_CLIENT_SECRET", "foo")
 	os.Setenv("NOZZLE_FIREHOSE_SUBSCRIPTION_ID", "foo")
+	os.Setenv("NOZZLE_PRELOAD_APP_CACHE", "true")
 	os.Setenv("WAVEFRONT_FLUSH_INTERVAL", "1")
 	os.Setenv("WAVEFRONT_PREFIX", "foo")
 	os.Setenv("WAVEFRONT_FOUNDATION", "foo")

--- a/nozzle/nozzle.go
+++ b/nozzle/nozzle.go
@@ -86,7 +86,7 @@ func (s *forwardingNozzle) handleEvent(envelope *events.Envelope) {
 	case events.Envelope_ContainerMetric:
 		appGuIG := envelope.GetContainerMetric().GetApplicationId()
 		appInfo, err := s.fetcher.GetApp(appGuIG)
-		if err != nil && debug {
+		if err != nil {
 			logger.Print("[ERROR]", err)
 		}
 		s.eventSerializer.BuildContainerEvent(envelope, appInfo)

--- a/nozzle/preloaded_cache.go
+++ b/nozzle/preloaded_cache.go
@@ -68,7 +68,8 @@ func (p *PreloadedCache) load() {
 	newApps := NewRandomEvictionCache(s)
 
 	for _, app := range pinfo {
-		newApps.Set(app.Guid, &app, 10*time.Minute)
+		cp := app // Make sure we get a copy of the app and not the loop variant!
+		newApps.Set(app.Guid, &cp, 10*time.Minute)
 	}
 
 	// Atomically overwrite old cache with new

--- a/nozzle/preloaded_cache.go
+++ b/nozzle/preloaded_cache.go
@@ -1,0 +1,75 @@
+package nozzle
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type PreloadedCache struct {
+	apps        *RandomEvictionCache
+	appCacheURL string
+	mux         sync.RWMutex
+}
+
+func NewPreloadedCache(appCacheURL string) *PreloadedCache {
+	p := &PreloadedCache{
+		appCacheURL: appCacheURL,
+	}
+	p.load()
+	go p.loader()
+	return p
+}
+
+func (p *PreloadedCache) Get(key string) (interface{}, bool) {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	return p.apps.Get(key)
+}
+
+func (p *PreloadedCache) Set(key string, value interface{}, ttl time.Duration) {
+	p.mux.RLock()
+	defer p.mux.RUnlock()
+	p.apps.Set(key, value, ttl)
+}
+
+func (p *PreloadedCache) loader() {
+	t := time.Tick(5 * time.Minute)
+	for {
+		<-t
+		p.load()
+	}
+}
+
+func (p *PreloadedCache) load() {
+	pres, err := http.Get(p.appCacheURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pbody, err := ioutil.ReadAll(pres.Body)
+	pres.Body.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var pinfo []AppInfo
+	err = json.Unmarshal(pbody, &pinfo)
+
+	// Create new cache. We allow for an extra 100 apps to come in during the refresh period
+	newApps := NewRandomEvictionCache(len(pinfo) + 100)
+
+	for _, app := range pinfo {
+		newApps.Set(app.Guid, &app, 10*time.Minute)
+	}
+
+	// Atomically overwrite old cache with new
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	p.apps = newApps
+
+	logger.Printf("[DEBUG] Preloaded %d applications", len(pinfo))
+}

--- a/nozzle/preloaded_cache.go
+++ b/nozzle/preloaded_cache.go
@@ -3,37 +3,50 @@ package nozzle
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"sync"
 	"time"
 )
 
+// PreloadedCache is a cache that gets preloaded (and reloaded) from a REST-service returning an array of json-encoded AppInfo
+// structs. If can be used with a variety of custom services for obtaining application metadata. An example is available here:
+// https://github.com/influxdata/influxdb-firehose-nozzle/tree/master/app-api-example
 type PreloadedCache struct {
 	apps        *RandomEvictionCache
 	appCacheURL string
 	mux         sync.RWMutex
+	maxSize     int
 }
 
-func NewPreloadedCache(appCacheURL string) *PreloadedCache {
+// NewPreloadedCache creates a new PreloadedCache with a specified endpoint URL
+func NewPreloadedCache(appCacheURL string, maxSize int) *PreloadedCache {
 	p := &PreloadedCache{
 		appCacheURL: appCacheURL,
+		maxSize:     maxSize,
 	}
 	p.load()
 	go p.loader()
 	return p
 }
 
+// Get returns the value for the key if it exists. If it doesn't exist, (nil, false) is returned.
 func (p *PreloadedCache) Get(key string) (interface{}, bool) {
 	p.mux.RLock()
 	defer p.mux.RUnlock()
+	if p.apps == nil {
+		return nil, false
+	}
 	return p.apps.Get(key)
 }
 
+// Set puts a key-value pair into the cache. If the cache is at capacity, some item will get evicted. The cache always
+// looks for expired items to evict first before it starts evicting live data at random.
 func (p *PreloadedCache) Set(key string, value interface{}, ttl time.Duration) {
 	p.mux.RLock()
 	defer p.mux.RUnlock()
-	p.apps.Set(key, value, ttl)
+	if p.apps != nil {
+		p.apps.Set(key, value, ttl)
+	}
 }
 
 func (p *PreloadedCache) loader() {
@@ -47,20 +60,28 @@ func (p *PreloadedCache) loader() {
 func (p *PreloadedCache) load() {
 	pres, err := http.Get(p.appCacheURL)
 	if err != nil {
-		log.Fatal(err)
+		logger.Printf("[ERROR] Could not load cache. Will keep old cache")
+		p.ensureCache()
+		return
 	}
 
 	pbody, err := ioutil.ReadAll(pres.Body)
 	pres.Body.Close()
 	if err != nil {
-		log.Fatal(err)
+		logger.Printf("[ERROR] Could not load cache. Will keep old cache")
+		p.ensureCache()
+		return
 	}
 
 	var pinfo []AppInfo
 	err = json.Unmarshal(pbody, &pinfo)
 
 	// Create new cache. We allow for an extra 100 apps to come in during the refresh period
-	newApps := NewRandomEvictionCache(len(pinfo) + 100)
+	s := len(pinfo) + 100
+	if s > p.maxSize {
+		s = p.maxSize
+	}
+	newApps := NewRandomEvictionCache(s)
 
 	for _, app := range pinfo {
 		newApps.Set(app.Guid, &app, 10*time.Minute)
@@ -72,4 +93,13 @@ func (p *PreloadedCache) load() {
 	p.apps = newApps
 
 	logger.Printf("[DEBUG] Preloaded %d applications", len(pinfo))
+}
+
+func (p *PreloadedCache) ensureCache() {
+	// Make sure we don't have an empty cache
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	if p.apps == nil {
+		p.apps = NewRandomEvictionCache(p.maxSize)
+	}
 }

--- a/nozzle/preloaded_cache_test.go
+++ b/nozzle/preloaded_cache_test.go
@@ -1,0 +1,50 @@
+package nozzle
+
+import (
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+)
+
+type DummyPreloader struct {
+	size int
+	ai []AppInfo
+}
+
+func (d *DummyPreloader) GetAllApps() ([]AppInfo, error) {
+	for i := 0; i < d.size; i++ {
+		uuid, err  := uuid.NewRandom()
+		if err != nil {
+			return nil, err
+		}
+		s := strconv.Itoa(i)
+		d.ai[i].Guid = uuid.String()
+		d.ai[i].Name = "Name_" + s
+		d.ai[i].Org = "Org_" + s
+		d.ai[i].Space = "Space_" + s
+	}
+	return d.ai, nil
+}
+
+func TestOversizedPreloadedCache(t *testing.T) {
+	pl := &DummyPreloader{ size:1000, ai: make([]AppInfo, 1000) }
+	c := NewPreloadedCache(pl, 2000)
+	for _, ai := range pl.ai {
+		cai, ok := c.Get(ai.Guid)
+		if ok {
+			assert.Equal(t, ai.Guid, cai.(*AppInfo).Guid)
+		}
+	}
+}
+
+func TestUndersizedPreloadedCache(t *testing.T) {
+	pl := &DummyPreloader{ size:1000, ai: make([]AppInfo, 1000) }
+	c := NewPreloadedCache(pl, 200)
+	for _, ai := range pl.ai {
+		cai, ok := c.Get(ai.Guid)
+		if ok {
+			assert.Equal(t, ai.Guid, cai.(*AppInfo).Guid)
+		}
+	}
+}

--- a/nozzle/preloaders.go
+++ b/nozzle/preloaders.go
@@ -1,0 +1,68 @@
+package nozzle
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cloudfoundry-community/go-cfclient"
+)
+
+// CFPreloader is a Preloader that reads directly from the CF API
+type CFPreloader struct {
+	client *cfclient.Client
+}
+
+// ExternalPreloader loads application info from an external source. An example is available here:
+// https://github.com/influxdata/influxdb-firehose-nozzle/tree/master/app-api-example
+type ExternalPreloader struct {
+	url string
+}
+
+// NewCFPreloader creates a new Preloader that wraps the supplied CF client
+func NewCFPreloader(client *cfclient.Client) Preloader {
+	return &CFPreloader{
+		client: client,
+	}
+}
+
+// GetAllApps loads the entire list of applications
+func (c *CFPreloader) GetAllApps() ([]AppInfo, error) {
+	apps, err := c.client.ListApps()
+	if err != nil {
+		return nil, err
+	}
+	ai := make([]AppInfo, len(apps))
+	for i, a := range apps {
+		ai[i].Guid = a.Guid
+		ai[i].Name = a.Name
+		ai[i].Org = a.SpaceData.Entity.OrgData.Entity.Name
+		ai[i].Space = a.SpaceData.Entity.Name
+	}
+	return ai, nil
+}
+
+// NewExternalPreloader returns a preloader connected to an external source
+func NewExternalPreloader(url string) Preloader {
+	return &ExternalPreloader{
+		url: url,
+	}
+}
+
+// GetAllApps loads the entire list of applications
+func (e *ExternalPreloader) GetAllApps() ([]AppInfo, error) {
+	pres, err := http.Get(e.url)
+	if err != nil {
+		return nil, err
+	}
+
+	pbody, err := ioutil.ReadAll(pres.Body)
+	pres.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	var ai []AppInfo
+	err = json.Unmarshal(pbody, &ai)
+	return ai, nil
+}

--- a/nozzle/recache.go
+++ b/nozzle/recache.go
@@ -1,0 +1,112 @@
+package nozzle
+
+import (
+	"container/heap"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+type cacheEntry struct {
+	key        string
+	value      interface{}
+	index      int
+	expiration int64
+}
+
+type cacheEntries []*cacheEntry
+
+func (ce cacheEntries) Len() int { return len(ce) }
+
+func (ce cacheEntries) Less(i, j int) bool {
+	return ce[i].expiration < ce[j].expiration
+}
+
+func (ce cacheEntries) Swap(i, j int) {
+	ce[i], ce[j] = ce[j], ce[i]
+	ce[i].index = i
+	ce[j].index = j
+}
+
+func (ce *cacheEntries) Push(x interface{}) {
+	n := len(*ce)
+	item := x.(*cacheEntry)
+	item.index = n
+	*ce = append(*ce, item)
+}
+
+func (ce *cacheEntries) Pop() interface{} {
+	old := *ce
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*ce = old[0 : n-1]
+	return item
+}
+
+// RandomeEvictionCache implements a cache with a random eviction policy. LRU caches suffer from very poor performance
+// when data is read in a predicable sequence from an undersized cache. Since we expect the sequence of data on the nozzle
+// to be predicable, this type of cache probably performs better.
+type RandomEvictionCache struct {
+	keys    map[string]*cacheEntry
+	entries cacheEntries
+	size    int
+	mux     sync.RWMutex
+}
+
+func NewRandomEvictionCache(size int) *RandomEvictionCache {
+	c := RandomEvictionCache{
+		keys:    make(map[string]*cacheEntry),
+		entries: make([]*cacheEntry, 0, size),
+		size:    size,
+	}
+	return &c
+}
+
+func (r *RandomEvictionCache) Get(key string) (interface{}, bool) {
+	r.mux.RLock()
+	defer r.mux.RUnlock()
+	if ce, ok := r.keys[key]; ok {
+		if ce.expiration < time.Now().UnixNano() {
+			return nil, false
+		}
+		return ce.value, true
+	}
+	return nil, false
+}
+
+func (r *RandomEvictionCache) Set(key string, value interface{}, ttl time.Duration) {
+	r.mux.Lock()
+	defer r.mux.Unlock()
+
+	expiration := time.Now().Add(ttl).UnixNano()
+	ce := &cacheEntry{
+		expiration: expiration,
+		index:      0,
+		key:        key,
+		value:      value,
+	}
+
+	// At capacity?
+	if len(r.entries) >= r.size {
+		// Can we get rid of an expired item?
+		var i int
+		if r.entries[0].expiration < time.Now().UnixNano() {
+			i = 0
+		} else {
+			// Pick a random item to overwrite
+			i = rand.Intn(len(r.entries))
+		}
+		delete(r.keys, r.entries[i].key)
+		ce.index = i
+		r.entries[i] = ce
+		r.keys[key] = ce
+		// Rebalance heap
+		heap.Fix(&r.entries, i)
+	} else {
+		// Not yet at capacity. Just push it.
+
+		heap.Push(&r.entries, ce)
+		r.keys[key] = ce
+	}
+}

--- a/nozzle/recache.go
+++ b/nozzle/recache.go
@@ -85,7 +85,7 @@ func (r *RandomEvictionCache) Set(key string, value interface{}, ttl time.Durati
 
 	var expiration int64
 	if ttl == 0 {
-		// No expiration (or at least way efter the Universe is gone...)
+		// No expiration (or at least way after the Universe is gone...)
 		expiration = math.MaxInt64
 	} else {
 		expiration = time.Now().Add(ttl).UnixNano()

--- a/nozzle/recache_test.go
+++ b/nozzle/recache_test.go
@@ -34,9 +34,10 @@ func TestUndersizedCache(t *testing.T) {
 	}
 	hits := 0
 	for i := 0; i < 2000; i++ {
-		_, ok := c.Get(strconv.Itoa(i))
+		v, ok := c.Get(strconv.Itoa(i))
 		if ok {
 			hits++
+			assert.Equal(t, strconv.Itoa(i), v)
 		}
 	}
 	assert.True(t, hits > 900, fmt.Sprintf("Not enough hits: %d", hits))

--- a/nozzle/recache_test.go
+++ b/nozzle/recache_test.go
@@ -1,0 +1,70 @@
+package nozzle
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func checkEntry(t *testing.T, c *RandomEvictionCache, key string) {
+	v, ok := c.Get(key)
+	assert.True(t, ok)
+	assert.Equal(t, key, v)
+}
+
+func TestOversizedCache(t *testing.T) {
+	c := NewRandomEvictionCache(1000)
+	for i := 0; i < 1000; i++ {
+		s := strconv.Itoa(i)
+		c.Set(s, s, 1*time.Hour)
+	}
+	for i := 0; i < 1000; i++ {
+		checkEntry(t, c, strconv.Itoa(i))
+	}
+}
+
+func TestUndersizedCache(t *testing.T) {
+	c := NewRandomEvictionCache(1000)
+	for i := 0; i < 2000; i++ {
+		s := strconv.Itoa(i)
+		c.Set(s, s, 1*time.Hour)
+	}
+	hits := 0
+	for i := 0; i < 2000; i++ {
+		_, ok := c.Get(strconv.Itoa(i))
+		if ok {
+			hits++
+		}
+	}
+	assert.True(t, hits > 900, fmt.Sprintf("Not enough hits: %d", hits))
+	assert.True(t, hits < 1100, fmt.Sprintf("Too many hits: %d", hits))
+	assert.Equal(t, 1000, len(c.entries))
+}
+
+func TestExpiration2(t *testing.T) {
+	c := NewRandomEvictionCache(500)
+
+	for i := 0; i < 500; i++ {
+		s := strconv.Itoa(i)
+		c.Set(s, s, 1*time.Microsecond)
+	}
+	time.Sleep(1 * time.Second) // Wait for entriex to expire
+	for i := 500; i < 1000; i++ {
+		s := strconv.Itoa(i)
+		c.Set(s, s, 1*time.Hour)
+	}
+
+	for i := 500; i < 1000; i++ {
+		checkEntry(t, c, strconv.Itoa(i))
+	}
+	for i := 0; i < 500; i++ {
+		{
+			s := strconv.Itoa(i)
+			_, ok := c.Get(s)
+			assert.False(t, ok, "Expired key was found")
+		}
+	}
+}

--- a/nozzle/structs.go
+++ b/nozzle/structs.go
@@ -1,5 +1,6 @@
 package nozzle
 
+// AppInfo is the struct returned from cache preloaders.
 type AppInfo struct {
 	Name  string `json:"name,omitempty"`
 	Guid  string `json:"guid,omitempty"`

--- a/nozzle/structs.go
+++ b/nozzle/structs.go
@@ -1,0 +1,8 @@
+package nozzle
+
+type AppInfo struct {
+	Name  string `json:"name,omitempty"`
+	Guid  string `json:"guid,omitempty"`
+	Space string `json:"space,omitempty"`
+	Org   string `json:"org,omitempty"`
+}

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 export NOZZLE_API_URL=https://api.<domain>
-export NOZZLE_USERNAME=<usr>
-export NOZZLE_PASSWORD=<pass>
+export NOZZLE_CLIENT_ID=<client id>
+export NOZZLE_CLIENT_SECRET=<client secret>
 export NOZZLE_FIREHOSE_SUBSCRIPTION_ID=firehose-subscription-id
 export NOZZLE_SKIP_SSL=true
 export NOZZLE_SELECTED_EVENTS=ValueMetric,CounterEvent,ContainerMetric


### PR DESCRIPTION
Added support for an external cache that follows the protocol of the InfluxDB sample provided here: https://github.com/influxdata/influxdb-firehose-nozzle/tree/master/app-api-example

Changed default cache to use a random eviction algorithm, which should be more efficient, since there's a lot of sequential reading. 