### PR TITLE
Adding Support for Sending Metrics as Histograms

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -5,11 +5,14 @@ code.cloudfoundry.org/go-diodes v0.0.0-20190809170250-f77fb823c7ee h1:iAAPf9s7/+
 code.cloudfoundry.org/go-diodes v0.0.0-20190809170250-f77fb823c7ee/go.mod h1:Jzi+ccHgo/V/PLQUaQ6hnZcC1c4BS790gx21LRRui4g=
 code.cloudfoundry.org/go-loggregator/v8 v8.0.1 h1:8PXkkv6o99HfccYBqZnQ9FIAVlVGuwxz7wyw2N4Dd2w=
 code.cloudfoundry.org/go-loggregator/v8 v8.0.1/go.mod h1:L+av5O/2IFEZiLkNm5dclQxuLe2adTUVH9YlcQe9zmc=
+code.cloudfoundry.org/gofileutils v0.0.0-20170111115228-4d0c80011a0f h1:UrKzEwTgeiff9vxdrfdqxibzpWjxLnuXDI5m6z3GJAk=
 code.cloudfoundry.org/gofileutils v0.0.0-20170111115228-4d0c80011a0f/go.mod h1:sk5LnIjB/nIEU7yP5sDQExVm62wu0pBh3yrElngUisI=
+code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a h1:8rqv2w8xEceNwckcF5ONeRt0qBHlh5bnNfFnYTrZbxs=
 code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a/go.mod h1:tkZo8GtzBjySJ7USvxm4E36lNQw1D3xM6oKHGqdaAJ4=
 code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 h1:2Qal+q+tw/DmDOoJBWwDCPE3lIJNj/1o7oMkkb2c5SI=
 code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3/go.mod h1:eTbFJpyXRGuFVyg5+oaj9B2eIbIc+0/kZjH8ftbtdew=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/apoydence/eachers v0.0.0-20181020210610-23942921fe77 h1:afT88tB6u9JCKQZVAAaa9ICz/uGn5Uw9ekn6P22mYKM=
@@ -21,6 +24,7 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20200413172050-18981bf12b4b h1:DxtGfGx/LJEIa9ZswJw097bz6CGQdaq2m9XFFuzomg8=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20200413172050-18981bf12b4b/go.mod h1:RtIewdO+K/czvxvIFCMbPyx7jdxSLL1RZ+DA/Vk8Lwg=
+github.com/cloudfoundry-incubator/uaago v0.0.0-20190307164349-8136b7bbe76e h1:DFYA2+zpeaTPEOizAJuaee2O7YX3UP5tOMjkeXL8iLo=
 github.com/cloudfoundry-incubator/uaago v0.0.0-20190307164349-8136b7bbe76e/go.mod h1:8wJCVaTSjT8phXCkbZWAKIB9JU8BEVHbnSbLgkr8WfY=
 github.com/cloudfoundry/dropsonde v1.0.0/go.mod h1:6zwvrWK5TpxBVYi1cdkE5WDsIO8E0n7qAJg3wR9B67c=
 github.com/cloudfoundry/gosteno v0.0.0-20150423193413-0c8581caea35/go.mod h1:3YBPUR85RIrvaUTdA1dL38YSp6s3OHu1xrWLkGt2Mog=
@@ -51,12 +55,14 @@ github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AE
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -97,6 +103,7 @@ github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2 h1:CXwSGu/LYmbjEab
 github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2/go.mod h1:L3UMQOThbttwfYRNFOWLLVXMhk5Lkio4GGOtw5UrxS0=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/eachers v0.0.0-20181020210610-23942921fe77 h1:SNdqPRvRsVmYR0gKqFvrUKhFizPJ6yDiGQ++VAJIoDg=
@@ -118,6 +125,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli v1.21.0/go.mod h1:lxDj6qX9Q6lWQxIrbrT0nwecwUtRnhVZAJjJZrVUZZQ=
+github.com/wavefronthq/go-metrics-wavefront v1.0.2 h1:6glPNj6QzTVQD0KA9+WKpAAkkkydlXe0YAcUXkyEdLQ=
 github.com/wavefronthq/go-metrics-wavefront v1.0.2/go.mod h1:HuUs+CDX00uWJbnbk2vbnG+tko6hN1pdnC6qaHK/9Fo=
 github.com/wavefronthq/wavefront-sdk-go v0.9.5/go.mod h1:w1jMUOL5ARz+qQTdqwkeNfY9Cp0bB+90jThq169rKFA=
 github.com/wavefronthq/wavefront-sdk-go v0.9.7 h1:SrtABcXXeKCW5SerQYsnCzHo15GeggjZmL+DjtTy6CI=
@@ -142,6 +150,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1 h1:VeAkjQVzKLmu+JnFcK96TPbkuaTIqwGGAzQ9hgwPjVg=
 golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -154,6 +163,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 h1:LepdCS8Gf/MVejFIt8lsiexZATdoGVyp5bcyS+rYoUI=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,16 +40,16 @@ type NozzleConfig struct {
 
 // WavefrontConfig holds specific Wavefront env variables
 type WavefrontConfig struct {
-	URL           string `envconfig:"URL"`
-	Token         string `envconfig:"API_TOKEN"`
-	ProxyAddr     string `envconfig:"PROXY_ADDR"`
-	ProxyPort     int    `envconfig:"PROXY_PORT"`
-	FlushInterval int    `default:"5" envconfig:"FLUSH_INTERVAL"`
-	MaxBufferSize int    `default:"100000" envconfig:"MAX_BUFFER_SIZE"`
-	BatchSize     int    `default:"10000" envconfig:"BATCH_SIZE"`
-	Prefix        string `required:"true" envconfig:"PREFIX"`
-	Foundation    string `required:"true" envconfig:"FOUNDATION"`
-	ProxyHisToMinPort int `default:"40001" envconfig:"PROXY_HISTOGRAM_MINUTE_PORT"`
+	URL               string `envconfig:"URL"`
+	Token             string `envconfig:"API_TOKEN"`
+	ProxyAddr         string `envconfig:"PROXY_ADDR"`
+	ProxyPort         int    `envconfig:"PROXY_PORT"`
+	FlushInterval     int    `default:"5" envconfig:"FLUSH_INTERVAL"`
+	MaxBufferSize     int    `default:"100000" envconfig:"MAX_BUFFER_SIZE"`
+	BatchSize         int    `default:"10000" envconfig:"BATCH_SIZE"`
+	Prefix            string `required:"true" envconfig:"PREFIX"`
+	Foundation        string `required:"true" envconfig:"FOUNDATION"`
+	ProxyHisToMinPort int    `default:"40001" envconfig:"PROXY_HISTOGRAM_MINUTE_PORT"`
 
 	Filters *filter.Filters `ignored:"true"`
 }
@@ -63,7 +63,7 @@ type advancedConfig struct {
 		MetricsBlackList string   `json:"filter_metrics_black_list"`
 		MetricsWhiteList string   `json:"filter_metrics_white_list"`
 		LegacyMode       bool     `json:"legacy_mode"`
-		MetricsToHisList  string  `json:"metrics_to_histogram_filter"`
+		MetricsToHisList string   `json:"metrics_to_histogram_filter"`
 	} `json:"selected_option"`
 }
 
@@ -80,7 +80,7 @@ func (ac *advancedConfig) haveCustomProxy() bool {
 type filtersConfig struct {
 	MetricsBlackList []string `split_words:"true"`
 	MetricsWhiteList []string `split_words:"true"`
-	MetricsToHisList  []string `split_words:"true"`
+	MetricsToHisList []string `split_words:"true"`
 
 	MetricsTagBlackList filter.TagFilter `split_words:"true"`
 	MetricsTagWhiteList filter.TagFilter `split_words:"true"`
@@ -115,7 +115,7 @@ func ParseConfig() (*Config, error) {
 	if nozzleConfig.AdvancedConfig.haveCustomProxy() {
 		wavefrontConfig.ProxyAddr = nozzleConfig.AdvancedConfig.Values.ProxyAddress
 		wavefrontConfig.ProxyPort = nozzleConfig.AdvancedConfig.Values.ProxyPort
-		wavefrontConfig.ProxyHisToMinPort =  nozzleConfig.AdvancedConfig.Values.ProxyHisMinPort
+		wavefrontConfig.ProxyHisToMinPort = nozzleConfig.AdvancedConfig.Values.ProxyHisMinPort
 	}
 
 	if len(nozzleConfig.AdvancedConfig.Values.MetricsWhiteList) > 0 {
@@ -136,7 +136,7 @@ func ParseConfig() (*Config, error) {
 	wavefrontConfig.Filters = &filter.Filters{
 		MetricsBlackList:    f.MetricsBlackList,
 		MetricsWhiteList:    f.MetricsWhiteList,
-		MetricsToHisList:     f.MetricsToHisList,
+		MetricsToHisList:    f.MetricsToHisList,
 		MetricsTagBlackList: f.MetricsTagBlackList,
 		MetricsTagWhiteList: f.MetricsTagWhiteList,
 		TagInclude:          f.TagInclude,

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -38,7 +38,7 @@ func (f *TagFilter) Decode(filters string) error {
 type Filters struct {
 	MetricsBlackList []string
 	MetricsWhiteList []string
-	MetricsToHisList  []string
+	MetricsToHisList []string
 
 	MetricsTagBlackList TagFilter
 	MetricsTagWhiteList TagFilter
@@ -50,7 +50,7 @@ type Filters struct {
 type globFilter struct {
 	metricWhitelist    glob.Glob
 	metricBlacklist    glob.Glob
-	metricsToHisList    glob.Glob
+	metricsToHisList   glob.Glob
 	metricTagWhitelist map[string]glob.Glob
 	metricTagBlacklist map[string]glob.Glob
 	tagInclude         glob.Glob
@@ -73,7 +73,7 @@ func NewGlobFilter(cfg *Filters) Filter {
 	return &globFilter{
 		metricWhitelist:    compile(cfg.MetricsWhiteList),
 		metricBlacklist:    compile(cfg.MetricsBlackList),
-		metricsToHisList:    compile(cfg.MetricsToHisList),
+		metricsToHisList:   compile(cfg.MetricsToHisList),
 		metricTagWhitelist: multiCompile(cfg.MetricsTagWhiteList),
 		metricTagBlacklist: multiCompile(cfg.MetricsTagBlackList),
 		tagInclude:         compile(cfg.TagInclude),

--- a/internal/wavefront/wavefront.go
+++ b/internal/wavefront/wavefront.go
@@ -23,10 +23,10 @@ type Wavefront interface {
 }
 
 type wavefront struct {
-	sender   senders.Sender
+	sender    senders.Sender
 	hisSender senders.Sender
-	reporter reporting.WavefrontMetricsReporter
-	filter   filter.Filter
+	reporter  reporting.WavefrontMetricsReporter
+	filter    filter.Filter
 
 	numMetricsSent     metrics.Counter
 	metricsSendFailure metrics.Counter
@@ -133,7 +133,7 @@ func (w *wavefront) SendMetric(name string, value float64, ts int64, source stri
 
 	if w.filter.Match(name, tags) {
 		start := time.Now()
-		if w.filter.IsHistogramMetric(name){
+		if w.filter.IsHistogramMetric(name) {
 			err = w.hisSender.SendMetric(name, value, ts, source, tags)
 		} else {
 			err = w.sender.SendMetric(name, value, ts, source, tags)


### PR DESCRIPTION
With the new fix, the user can provide the Glob Patterns and based on the Patterns nozzle will send all matching metrics to the port  40001 (histogramMinuteListenerPorts) of the proxy. Here we have enabled the same functionality for Custom Proxy also.

@laullon @srinivas-kandula 